### PR TITLE
Fixed: The certificate for deb.nodesource seems to be expired

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN apt-get update && apt-get install -y curl gnupg2 lsb-release && \
     npm install -g yarn && \
     yarn -v && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get install ca-certificates


### PR DESCRIPTION
Recently, our android build job is started getting failed. It throws error on doing 'apt-get update' after environment spin up with this image. 
Facing below issue
`E: The repository 'https://deb.nodesource.com/node_14.x focal Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.`

There is open bug present on https://github.com/nodesource/distributions.
Issue : https://github.com/nodesource/distributions/issues/1266
