### PR TITLE
fix: install latest npm version for node 22

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 10 * * *" # everyday at 10am
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     branches: ["latest"]
   push:
     branches: ["latest"]
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref || github.ref }}
       - name: Set imageName based on the repository name
         id: step_one
         run: |
@@ -46,5 +48,6 @@ jobs:
         with:
           platforms: ${{ env.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
+          pull: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,11 @@ LABEL maintainer="hi@beevelop.com" \
       org.opencontainers.image.documentation="https://github.com/beevelop/docker-android-nodejs/blob/latest/README.md" \
       org.opencontainers.image.source="https://github.com/beevelop/docker-android-nodejs.git"
 
-# Install Node.js using NodeSource repository
-RUN apt-get update && apt-get install -y curl ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
-    apt-get install -y nodejs && \
+# Install Node.js 22 with compatible npm using official Node.js binaries
+ENV NODE_VERSION=22.18.0
+RUN apt-get update && apt-get install -y curl ca-certificates xz-utils && \
+    curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz | tar -xJ -C /usr/local --strip-components=1 && \
+    npm install -g npm@latest && \
     npm install -g yarn && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Node.js installation using official binaries and pinned to v22.18.0 for consistent builds; added support for compressed archives and cleanup to reduce image size.
  * Updated npm to latest and kept Yarn available.
  * Added build-time version checks for runtimes (Node, npm, Yarn, Java, Maven, Gradle, Ant).
  * CI/workflow tweaks to ensure PR builds use the correct ref and pull base images before building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->